### PR TITLE
Add hero-mosh header to home, reviews and tools

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -87,6 +87,59 @@ body {
   max-width: 960px;
 }
 
+.hero-header {
+  background: var(--surface);
+  color: var(--text);
+  padding: clamp(32px, 5vw, 44px) clamp(24px, 4vw, 40px);
+  text-align: center;
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.hero-header .hero-mosh {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.18;
+  mix-blend-mode: multiply;
+  filter: grayscale(1) contrast(1.05);
+  -webkit-mask-image: linear-gradient(
+    to right,
+    #000 0%,
+    #000 22%,
+    transparent 40%,
+    transparent 60%,
+    #000 78%,
+    #000 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    #000 0%,
+    #000 22%,
+    transparent 40%,
+    transparent 60%,
+    #000 78%,
+    #000 100%
+  );
+}
+
+.hero-header > :not(.hero-mosh) {
+  position: relative;
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-header .hero-mosh {
+    display: none;
+  }
+}
+
 .card h2 {
   font-family: var(--font-sans);
   font-size: clamp(2rem, 4vw, 2.4rem);

--- a/assets/hero-mosh.js
+++ b/assets/hero-mosh.js
@@ -1,0 +1,110 @@
+(() => {
+  const prefersReducedMotion = () =>
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+  const createNoise = () => {
+    const noise = document.createElement('canvas');
+    const size = 256;
+    noise.width = size;
+    noise.height = size;
+    const nctx = noise.getContext('2d', { alpha: true });
+    const img = nctx.createImageData(size, size);
+    for (let i = 0; i < img.data.length; i += 4) {
+      const v = Math.random() * 255;
+      img.data[i] = v;
+      img.data[i + 1] = v;
+      img.data[i + 2] = v;
+      img.data[i + 3] = 35;
+    }
+    nctx.putImageData(img, 0, 0);
+    return noise;
+  };
+
+  const drawFallback = (ctx, w, h) => {
+    const gradient = ctx.createLinearGradient(0, 0, w, h);
+    gradient.addColorStop(0, 'rgba(111, 76, 30, 0.25)');
+    gradient.addColorStop(1, 'rgba(255, 255, 255, 0.6)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, w, h);
+  };
+
+  const initHeader = (header) => {
+    const canvas = header.querySelector('.hero-mosh');
+    if (!canvas || prefersReducedMotion()) return;
+
+    const ctx = canvas.getContext('2d', { alpha: true });
+    const mosh = document.createElement('canvas');
+    const mctx = mosh.getContext('2d', { alpha: true });
+    const base = document.createElement('canvas');
+    const bctx = base.getContext('2d', { alpha: true });
+    const noise = createNoise();
+
+    const state = {
+      w: 0,
+      h: 0,
+      dpr: 1,
+      raf: 0,
+      last: 0,
+      burst: 0,
+    };
+
+    const setSize = () => {
+      const rect = header.getBoundingClientRect();
+      const dpr = clamp(window.devicePixelRatio || 1, 1, 2);
+      const w = Math.max(1, Math.floor(rect.width * dpr));
+      const h = Math.max(1, Math.floor(rect.height * dpr));
+      state.w = w;
+      state.h = h;
+      state.dpr = dpr;
+      canvas.width = w;
+      canvas.height = h;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+      base.width = w;
+      base.height = h;
+      mosh.width = w;
+      mosh.height = h;
+      drawFallback(bctx, w, h);
+    };
+
+    const distort = () => {
+      const { w, h } = state;
+      const sx = (Math.random() - 0.5) * 18;
+      const sy = (Math.random() - 0.5) * 8;
+      mctx.globalCompositeOperation = 'source-over';
+      mctx.clearRect(0, 0, w, h);
+      mctx.drawImage(base, 0, 0);
+      mctx.globalCompositeOperation = 'lighter';
+      mctx.drawImage(noise, 0, 0, w, h);
+      mctx.globalCompositeOperation = 'source-over';
+      mctx.drawImage(base, sx, sy, w, h);
+    };
+
+    const render = (ts) => {
+      const { w, h } = state;
+      const dt = ts - state.last;
+      state.last = ts;
+      if (Math.random() > 0.94) {
+        state.burst = clamp(state.burst + 0.5, 0, 1);
+      } else {
+        state.burst = clamp(state.burst - dt * 0.0006, 0, 1);
+      }
+      distort();
+      ctx.clearRect(0, 0, w, h);
+      ctx.globalAlpha = 0.5 + state.burst * 0.3;
+      ctx.drawImage(mosh, 0, 0);
+      ctx.globalAlpha = 1;
+      state.raf = requestAnimationFrame(render);
+    };
+
+    setSize();
+    window.addEventListener('resize', setSize, { passive: true });
+    state.raf = requestAnimationFrame(render);
+  };
+
+  const headers = document.querySelectorAll('.hero-header');
+  headers.forEach((header) => initHeader(header));
+})();

--- a/index.html
+++ b/index.html
@@ -34,15 +34,19 @@
             </nav>
         </aside>
         <main class="content">
-            <section class="card">
-                <h2>Willkommen!</h2>
-                <p>
-                    This is the zerro-page of the personal site. It contains key links that are important to me: 
-					cv & reviews on bugs, as well as other links to interesting resources related to secure development and dynamic testing.
-                </p>
+            <section class="card card--wide">
+                <header class="hero-header">
+                    <canvas class="hero-mosh" aria-hidden="true"></canvas>
+                    <h2>Willkommen!</h2>
+                    <p>
+                        This is the zerro-page of the personal site. It contains key links that are important to me:
+                        cv & reviews on bugs, as well as other links to interesting resources related to secure development and dynamic testing.
+                    </p>
+                </header>
             </section>
         </main>
     </div>
+    <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>
 

--- a/reviews/index.html
+++ b/reviews/index.html
@@ -34,13 +34,17 @@
             </nav>
         </aside>
         <main class="content">
-            <section class="card">
-                <h2>Reviews</h2>
-                <p>
-					Bug reviews, test reports and brief methodology notes
-                </p>
+            <section class="card card--wide">
+                <header class="hero-header">
+                    <canvas class="hero-mosh" aria-hidden="true"></canvas>
+                    <h2>Reviews</h2>
+                    <p>
+                        Bug reviews, test reports and brief methodology notes
+                    </p>
+                </header>
             </section>
         </main>
     </div>
+    <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -34,9 +34,12 @@
       </nav>
     </aside>
     <main class="content">
-      <section class="card">
-        <h2>Tools</h2>
-        <p>Small collection of browser-based utilities and demos.</p>
+      <section class="card card--wide">
+        <header class="hero-header">
+          <canvas class="hero-mosh" aria-hidden="true"></canvas>
+          <h2>Tools</h2>
+          <p>Small collection of browser-based utilities and demos.</p>
+        </header>
       </section>
 
       <section class="card">
@@ -47,5 +50,6 @@
       </section>
     </main>
   </div>
+  <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Apply the same `heroMosh` visual treatment used on the `/cv/` page to the wide card headers on the main pages for visual consistency.
- Provide a shared, reusable header pattern for `card--wide` sections so other pages can opt into the effect.
- Respect reduced-motion preferences and keep the effect non-blocking by using a separate script and `canvas` overlay.

### Description
- Add shared header styles in `assets/base.css` under the `.hero-header` rule to match the CV hero look and layer a `.hero-mosh` canvas above it.
- Add a new animation script `assets/hero-mosh.js` that draws a subtle datamosh/noise effect into header canvases and respects `prefers-reduced-motion`.
- Replace the simple `section.card` blocks on `index.html`, `reviews/index.html`, and `tools/index.html` with `section.card card--wide` containing a `header.hero-header` and a `<canvas class="hero-mosh">` element, and load the script with `defer`.

### Testing
- Started a local server via `python -m http.server` to serve the static site (server started successfully).
- Attempted an automated Playwright screenshot to validate rendering, but the Playwright browser crashed in the container and the screenshot step failed.
- No further automated tests were run; changes are static HTML/CSS/JS updates and were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5ffa6fa08322b4dd4064606dc2fe)