### PR TITLE
Enhance .card styling to match CV hero (gradients, inset borders, shine)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -80,7 +80,35 @@ body {
   background: var(--surface);
   padding: clamp(28px, 4vw, 40px);
   border-radius: 18px;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08), inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.9), transparent 60%),
+    linear-gradient(160deg, rgba(111, 76, 30, 0.07), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(30, 30, 30, 0.08);
+  pointer-events: none;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .card--wide {


### PR DESCRIPTION
### Motivation
- Unify the visual appearance of generic cards with the main CV hero card by adding the same subtle effects and borders.
- Make `card` elements feel more three-dimensional and consistent across pages such as `/tools/`, `/reviews/` and the homepage.

### Description
- Updated `assets/base.css` to extend the `.card` rule with `border`, `inset` shadow and `position: relative`/`overflow: hidden` to enable layered effects.
- Added `.card::before` to render a soft top radial highlight and a warm linear wash, and `.card::after` to draw a subtle inner border inset.
- Ensured card content stays above the effects by setting `.card > * { position: relative; z-index: 1; }`.
- These changes are purely presentational and affect all pages that use the `.card` class.

### Testing
- Launched a local server with `python -m http.server 8000` and captured a screenshot of `/tools/` using a Playwright script, which produced `artifacts/tools-cards.png` successfully. 
- No unit tests were required for this static CSS change and visual verification was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f89f06460832298dd0c3df4dfcca9)