### PR TITLE
Add 'Full list of open-source contributions' accordion to CV

### DIFF
--- a/assets/cv.css
+++ b/assets/cv.css
@@ -551,6 +551,67 @@ font-size: 1.2rem;
 margin-top: 3px;
 }
 
+.contributions-details {
+margin-top: 24px;
+border: 1px solid rgba(0, 0, 0, 0.1);
+border-radius: 12px;
+background: rgba(255, 255, 255, 0.9);
+padding: 12px 18px;
+box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+font-family: var(--font-sans);
+}
+
+.contributions-details summary {
+cursor: pointer;
+list-style: none;
+font-weight: 700;
+display: flex;
+align-items: center;
+gap: 10px;
+}
+
+.contributions-details summary::-webkit-details-marker {
+display: none;
+}
+
+.contributions-details summary::before {
+content: "+";
+display: inline-flex;
+align-items: center;
+justify-content: center;
+width: 22px;
+height: 22px;
+border-radius: 6px;
+background: rgba(111, 76, 30, 0.12);
+color: var(--accent);
+font-weight: 700;
+}
+
+.contributions-details[open] summary::before {
+content: "–";
+}
+
+.contributions-details .details-body {
+margin-top: 12px;
+color: var(--muted);
+}
+
+.contributions-details ul {
+margin: 10px 0 16px;
+padding-left: 20px;
+display: grid;
+gap: 8px;
+}
+
+.contributions-details a {
+color: var(--accent);
+text-decoration: none;
+}
+
+.contributions-details a:hover {
+text-decoration: underline;
+}
+
 .tag-cloud {
 display: flex;
 flex-wrap: wrap;

--- a/cv/index.html
+++ b/cv/index.html
@@ -216,6 +216,34 @@
                 <a class="tag size-xs" href="https://bdu.fstec.ru/vul/2025-10088">BDU:2025-10088</a>
                 <a class="tag size-xs" href="https://bdu.fstec.ru/vul/2025-10089">BDU:2025-10089</a>
             </div>
+            <details class="contributions-details">
+                <summary>
+                    <span class="lang-en">Full list of open-source contributions</span>
+                    <span class="lang-ru">Полный список open-source contributions</span>
+                </summary>
+                <div class="details-body">
+                    <p class="lang-en">Projects and trackers</p>
+                    <p class="lang-ru">Проекты и трекеры</p>
+                    <ul class="lang-en">
+                        <li><a href="https://github.com/AFLplusplus/AFLplusplus" target="_blank" rel="noopener noreferrer">AFL++</a> — fuzzing tools and infrastructure.</li>
+                        <li><a href="https://github.com/nodejs/node" target="_blank" rel="noopener noreferrer">Node.js</a> — security hardening and bug reports.</li>
+                        <li><a href="https://github.com/python/cpython" target="_blank" rel="noopener noreferrer">Python (CPython)</a> — issue reports and test coverage.</li>
+                        <li><a href="https://github.com/danmar/cppcheck" target="_blank" rel="noopener noreferrer">Cppcheck</a> — static analysis improvements.</li>
+                        <li><a href="https://github.com/gpac/gpac" target="_blank" rel="noopener noreferrer">GPAC</a> — media pipeline issues.</li>
+                        <li><a href="https://github.com/libjxl/libjxl" target="_blank" rel="noopener noreferrer">JPEG XL</a> — codec testing and bug reports.</li>
+                    </ul>
+                    <ul class="lang-ru">
+                        <li><a href="https://github.com/AFLplusplus/AFLplusplus" target="_blank" rel="noopener noreferrer">AFL++</a> — инструменты и инфраструктура для фаззинга.</li>
+                        <li><a href="https://github.com/nodejs/node" target="_blank" rel="noopener noreferrer">Node.js</a> — усиление безопасности и отчёты о дефектах.</li>
+                        <li><a href="https://github.com/python/cpython" target="_blank" rel="noopener noreferrer">Python (CPython)</a> — репорты и тестовое покрытие.</li>
+                        <li><a href="https://github.com/danmar/cppcheck" target="_blank" rel="noopener noreferrer">Cppcheck</a> — улучшения статического анализа.</li>
+                        <li><a href="https://github.com/gpac/gpac" target="_blank" rel="noopener noreferrer">GPAC</a> — дефекты в медиапайплайне.</li>
+                        <li><a href="https://github.com/libjxl/libjxl" target="_blank" rel="noopener noreferrer">JPEG XL</a> — тестирование кодека и отчёты о дефектах.</li>
+                    </ul>
+                    <p class="lang-en">Public disclosures are linked above in the tag cloud.</p>
+                    <p class="lang-ru">Публичные раскрытия перечислены выше в облаке тегов.</p>
+                </div>
+            </details>
             
         </section>
 


### PR DESCRIPTION
### Motivation
- Provide a discoverable full list of open-source projects and trackers referenced from the CV contributions tag cloud. 
- Keep the main contributions section compact while offering an expanded, readable list for recruiters and reviewers. 
- Ensure bilingual support (English / Russian) consistent with the rest of the CV. 

### Description
- Added a collapsible block implemented with a `<details>` element using the class `contributions-details` under the contributions section in `cv/index.html`. 
- Populated the details body with bilingual lists linking to projects (`AFL++`, `Node.js`, `CPython`, `Cppcheck`, `GPAC`, `JPEG XL`) and a short disclosure line referencing the tag cloud. 
- Added CSS for the new block in `assets/cv.css`, styling the `contributions-details` summary, open state marker, body, lists and links to match CV typography. 
- Kept the tag cloud intact and linked the new details block visually below the cloud using existing layout styles. 

### Testing
- Started a simple static server (`python -m http.server`) and verified the modified page loads locally and the new HTML/CSS are present in `cv/index.html` and `assets/cv.css`. 
- Attempted a Playwright script to open `details.contributions-details` and capture a screenshot, but the Playwright run timed out locating the element (no page regressions observed in source). 
- No automated unit tests were applicable for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696136de4ba88322a68d6d89e1099eb9)