### PR TITLE
Apply CV engineering background across site (Houdini paint worklet)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -7,6 +7,19 @@
   --border: rgba(30, 30, 30, 0.12);
   --font-serif: 'Source Serif 4', 'Iowan Old Style', 'Palatino', 'Times New Roman', serif;
   --font-sans: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --eng-bg-grid: 28;
+  --eng-bg-major: 112;
+  --eng-bg-hatch: 160;
+  --eng-bg-seed: 1337;
+  --eng-bg-dpr: 1;
+  --eng-bg-phase: 0;
+  --eng-bg-grid-alpha: 0.055;
+  --eng-bg-major-alpha: 0.080;
+  --eng-bg-hatch-alpha: 0.035;
+  --eng-bg-noise-alpha: 0.028;
+  --eng-bg-scope-alpha: 0.055;
+  --eng-bg-scope-thickness: 1.15;
+  --eng-bg-cal-alpha: 0.050;
 }
 
 * {
@@ -202,5 +215,42 @@ body {
     border-right: none;
     border-bottom: 1px solid var(--border);
     padding: 32px 24px;
+  }
+}
+
+@supports (background-image: paint(engineeringBG)) {
+  body {
+    background-image: paint(engineeringBG);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+  }
+
+  @property --eng-bg-phase {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    body {
+      animation: engBgPhase 14s linear infinite;
+    }
+  }
+
+  @keyframes engBgPhase {
+    from { --eng-bg-phase: 0; }
+    to { --eng-bg-phase: 6.28318; }
+  }
+}
+
+@supports not (background-image: paint(engineeringBG)) {
+  body {
+    background-image:
+      repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.030) 0 1px, transparent 1px 28px),
+      repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.030) 0 1px, transparent 1px 28px),
+      repeating-linear-gradient(45deg, rgba(0, 0, 0, 0.020) 0 1px, transparent 1px 160px),
+      radial-gradient(circle at 50% 32%, rgba(0, 0, 0, 0.055), transparent 60%);
+    background-attachment: fixed;
   }
 }

--- a/assets/engineering-bg.js
+++ b/assets/engineering-bg.js
@@ -1,0 +1,230 @@
+(() => {
+  const initHoudiniEngineeringBG = () => {
+    if (!('paintWorklet' in CSS) || !CSS.paintWorklet) return;
+
+    const setDpr = () => {
+      const dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+      document.documentElement.style.setProperty('--eng-bg-dpr', String(dpr));
+    };
+    setDpr();
+    window.addEventListener('resize', setDpr, { passive: true });
+
+    const workletCode = `
+      /* Houdini Paint Worklet: engineeringBG */
+      const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+      const num = (props, name, fallback) => {
+        const v = props && props.get && props.get(name);
+        const n = parseFloat(v === undefined || v === null ? '' : String(v));
+        return Number.isFinite(n) ? n : fallback;
+      };
+
+      const makeRng = (seed) => {
+        let t = (seed >>> 0) || 1;
+        return () => {
+          t += 0x6D2B79F5;
+          let r = Math.imul(t ^ (t >>> 15), 1 | t);
+          r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+          return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+        };
+      };
+
+      const noise1 = (x, seed) => {
+        let n = ((x * 0.14) | 0) + (seed | 0);
+        n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+        n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+        n = (n ^ (n >>> 16)) >>> 0;
+        return (n / 4294967296) * 2 - 1;
+      };
+
+      class EngineeringBG {
+        static get inputProperties() {
+          return [
+            '--eng-bg-grid',
+            '--eng-bg-major',
+            '--eng-bg-hatch',
+            '--eng-bg-seed',
+            '--eng-bg-dpr',
+            '--eng-bg-phase',
+            '--eng-bg-grid-alpha',
+            '--eng-bg-major-alpha',
+            '--eng-bg-hatch-alpha',
+            '--eng-bg-noise-alpha',
+            '--eng-bg-scope-alpha',
+            '--eng-bg-scope-thickness',
+            '--eng-bg-cal-alpha',
+          ];
+        }
+
+        paint(ctx, geom, props) {
+          const w = Math.max(1, geom.width);
+          const h = Math.max(1, geom.height);
+
+          const dpr = clamp(num(props, '--eng-bg-dpr', 1), 1, 2);
+          const W = w / dpr;
+          const H = h / dpr;
+
+          const grid = clamp(num(props, '--eng-bg-grid', 28), 12, 84);
+          const major = clamp(num(props, '--eng-bg-major', grid * 4), grid * 2, grid * 14);
+          const hatch = clamp(num(props, '--eng-bg-hatch', 160), 70, 340);
+
+          const seed = (num(props, '--eng-bg-seed', 1337) | 0) >>> 0;
+          const phase = num(props, '--eng-bg-phase', 0);
+
+          const aGrid = clamp(num(props, '--eng-bg-grid-alpha', 0.055), 0, 0.25);
+          const aMajor = clamp(num(props, '--eng-bg-major-alpha', 0.080), 0, 0.35);
+          const aHatch = clamp(num(props, '--eng-bg-hatch-alpha', 0.035), 0, 0.25);
+          const aNoise = clamp(num(props, '--eng-bg-noise-alpha', 0.028), 0, 0.20);
+          const aScope = clamp(num(props, '--eng-bg-scope-alpha', 0.055), 0, 0.30);
+          const scopeW = clamp(num(props, '--eng-bg-scope-thickness', 1.15), 0.6, 2.2);
+          const aCal = clamp(num(props, '--eng-bg-cal-alpha', 0.050), 0, 0.22);
+
+          ctx.save();
+          ctx.scale(dpr, dpr);
+
+          ctx.lineWidth = 1;
+          ctx.strokeStyle = 'rgba(0,0,0,' + aGrid + ')';
+          ctx.beginPath();
+
+          const x0 = (seed % grid);
+          for (let x = x0; x <= W; x += grid) {
+            const xx = (x | 0) + 0.5;
+            ctx.moveTo(xx, 0);
+            ctx.lineTo(xx, H);
+          }
+
+          const y0 = ((seed * 3) % grid);
+          for (let y = y0; y <= H; y += grid) {
+            const yy = (y | 0) + 0.5;
+            ctx.moveTo(0, yy);
+            ctx.lineTo(W, yy);
+          }
+          ctx.stroke();
+
+          ctx.strokeStyle = 'rgba(0,0,0,' + aMajor + ')';
+          ctx.beginPath();
+
+          const mx0 = (seed % major);
+          for (let x = mx0; x <= W; x += major) {
+            const xx = (x | 0) + 0.5;
+            ctx.moveTo(xx, 0);
+            ctx.lineTo(xx, H);
+          }
+
+          const my0 = ((seed * 5) % major);
+          for (let y = my0; y <= H; y += major) {
+            const yy = (y | 0) + 0.5;
+            ctx.moveTo(0, yy);
+            ctx.lineTo(W, yy);
+          }
+          ctx.stroke();
+
+          if (aHatch > 0) {
+            ctx.strokeStyle = 'rgba(0,0,0,' + aHatch + ')';
+            ctx.beginPath();
+
+            const diag = Math.sqrt(W * W + H * H);
+            const start = -diag;
+            const end = diag * 2;
+            for (let t = start; t < end; t += hatch) {
+              ctx.moveTo(t, -20);
+              ctx.lineTo(t + H + 20, H + 20);
+            }
+            ctx.stroke();
+          }
+
+          if (aCal > 0) {
+            const cx = W * 0.5;
+            const cy = H * 0.32;
+            const baseR = Math.min(W, H) * 0.10;
+
+            ctx.strokeStyle = 'rgba(0,0,0,' + aCal + ')';
+            ctx.lineWidth = 1;
+            ctx.setLineDash([6, 10]);
+
+            for (let i = 0; i < 3; i++) {
+              const r = baseR * (1 + i * 0.85);
+              ctx.beginPath();
+              ctx.arc(cx, cy, r, 0, Math.PI * 2);
+              ctx.stroke();
+            }
+
+            ctx.setLineDash([]);
+
+            ctx.beginPath();
+            ctx.moveTo(cx - baseR * 2.1, cy + 0.5);
+            ctx.lineTo(cx + baseR * 2.1, cy + 0.5);
+            ctx.moveTo(cx + 0.5, cy - baseR * 2.1);
+            ctx.lineTo(cx + 0.5, cy + baseR * 2.1);
+            ctx.stroke();
+
+            const tick = Math.max(10, grid * 0.6);
+            const inset = Math.max(10, grid * 0.7);
+            ctx.beginPath();
+            ctx.moveTo(inset, inset + 0.5); ctx.lineTo(inset + tick, inset + 0.5);
+            ctx.moveTo(inset + 0.5, inset); ctx.lineTo(inset + 0.5, inset + tick);
+            ctx.moveTo(W - inset, inset + 0.5); ctx.lineTo(W - inset - tick, inset + 0.5);
+            ctx.moveTo(W - inset + 0.5, inset); ctx.lineTo(W - inset + 0.5, inset + tick);
+            ctx.moveTo(inset, H - inset + 0.5); ctx.lineTo(inset + tick, H - inset + 0.5);
+            ctx.moveTo(inset + 0.5, H - inset); ctx.lineTo(inset + 0.5, H - inset - tick);
+            ctx.moveTo(W - inset, H - inset + 0.5); ctx.lineTo(W - inset - tick, H - inset + 0.5);
+            ctx.moveTo(W - inset + 0.5, H - inset); ctx.lineTo(W - inset + 0.5, H - inset - tick);
+            ctx.stroke();
+          }
+
+          if (aScope > 0) {
+            ctx.strokeStyle = 'rgba(0,0,0,' + aScope + ')';
+            ctx.lineWidth = scopeW;
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+
+            const rows = 3;
+            for (let r = 0; r < rows; r++) {
+              const yBase = H * (0.54 + r * 0.14);
+              const freq = 1.6 + r * 0.35;
+              const amp = 3.8 + r * 1.1;
+
+              ctx.beginPath();
+              for (let x = 0; x <= W; x += 6) {
+                const s = Math.sin((x / W) * Math.PI * 2 * freq + phase * (0.7 + r * 0.2));
+                const n = noise1(x + r * 971, seed + r * 1013);
+                const y = yBase + s * amp + n * 1.6;
+                if (x === 0) ctx.moveTo(0, y);
+                else ctx.lineTo(x, y);
+              }
+              ctx.stroke();
+            }
+          }
+
+          if (aNoise > 0) {
+            const rng = makeRng(seed ^ 0x9E3779B9);
+            const count = Math.min(1800, Math.max(250, ((W * H) / 7000) | 0));
+            ctx.fillStyle = 'rgba(0,0,0,' + aNoise + ')';
+
+            for (let i = 0; i < count; i++) {
+              const x = (rng() * W) | 0;
+              const y = (rng() * H) | 0;
+              const s = rng() < 0.85 ? 1 : 2;
+              ctx.fillRect(x, y, s, s);
+            }
+          }
+
+          ctx.restore();
+        }
+      }
+
+      registerPaint('engineeringBG', EngineeringBG);
+    `;
+
+    try {
+      const blob = new Blob([workletCode], { type: 'application/javascript' });
+      const url = URL.createObjectURL(blob);
+      CSS.paintWorklet.addModule(url).finally(() => {
+        try { URL.revokeObjectURL(url); } catch (_) {}
+      });
+    } catch (e) {
+      // In case CSP disallows blob: URLs, we just silently skip
+    }
+  };
+
+  window.addEventListener('load', initHoudiniEngineeringBG);
+})();

--- a/assets/tools.css
+++ b/assets/tools.css
@@ -10,6 +10,19 @@ color-scheme: light dark;
 --input-bg: #ffffff;
 --input-fg: #111111;
 --input-border: #d0d7de;
+--eng-bg-grid: 28;
+--eng-bg-major: 112;
+--eng-bg-hatch: 160;
+--eng-bg-seed: 1337;
+--eng-bg-dpr: 1;
+--eng-bg-phase: 0;
+--eng-bg-grid-alpha: 0.055;
+--eng-bg-major-alpha: 0.080;
+--eng-bg-hatch-alpha: 0.035;
+--eng-bg-noise-alpha: 0.028;
+--eng-bg-scope-alpha: 0.055;
+--eng-bg-scope-thickness: 1.15;
+--eng-bg-cal-alpha: 0.050;
 }
 @media (prefers-color-scheme: dark) {
 :root {
@@ -72,3 +85,40 @@ pre { background: var(--pre-bg); padding: 8px; overflow-x: auto; font-size: 0.7r
 ul, ol { margin: 0 0 4px 18px; padding: 0; }
 li { font-size: 0.8rem; margin-bottom: 3px; }
 #footerNote { margin-top: 12px; font-size: 0.7rem; color: var(--muted); }
+
+@supports (background-image: paint(engineeringBG)) {
+  body {
+    background-image: paint(engineeringBG);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+  }
+
+  @property --eng-bg-phase {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    body {
+      animation: engBgPhase 14s linear infinite;
+    }
+  }
+
+  @keyframes engBgPhase {
+    from { --eng-bg-phase: 0; }
+    to { --eng-bg-phase: 6.28318; }
+  }
+}
+
+@supports not (background-image: paint(engineeringBG)) {
+  body {
+    background-image:
+      repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.030) 0 1px, transparent 1px 28px),
+      repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.030) 0 1px, transparent 1px 28px),
+      repeating-linear-gradient(45deg, rgba(0, 0, 0, 0.020) 0 1px, transparent 1px 160px),
+      radial-gradient(circle at 50% 32%, rgba(0, 0, 0, 0.055), transparent 60%);
+    background-attachment: fixed;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
             </section>
         </main>
     </div>
+    <script src="/assets/engineering-bg.js" defer></script>
     <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>

--- a/reviews/index.html
+++ b/reviews/index.html
@@ -45,6 +45,7 @@
             </section>
         </main>
     </div>
+    <script src="/assets/engineering-bg.js" defer></script>
     <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -50,6 +50,7 @@
       </section>
     </main>
   </div>
+  <script src="/assets/engineering-bg.js" defer></script>
   <script src="/assets/hero-mosh.js" defer></script>
 </body>
 </html>

--- a/tools/run.html
+++ b/tools/run.html
@@ -42,6 +42,7 @@
 
   <div id="footerNote">Для парсинга используется Kaitai Struct ELF JS-библиотека (Elf.js + KaitaiStream.js).</div>
 
+  <script src="/assets/engineering-bg.js" defer></script>
   <script src="KaitaiStream.js"></script>
   <script src="Elf.js"></script>
 


### PR DESCRIPTION
### Motivation
- Make non-CV pages use the same subtle engineering background as `cv/` so the site appearance is consistent across sections.
- Provide a progressive-enhancement implementation that uses the CSS Painting API (Houdini) when available with a graceful CSS fallback for other browsers.

### Description
- Added shared background custom properties and `@supports` blocks to `assets/base.css` and `assets/tools.css` to enable the engineering backdrop and a fallback tiled/grain pattern when Houdini is not available.
- Implemented a self-contained worklet loader `assets/engineering-bg.js` which registers the `engineeringBG` paint worklet and exposes DPR/phase controls via CSS custom properties.
- Included the background script on the main site pages by adding `<script src="/assets/engineering-bg.js" defer></script>` ahead of the existing `hero-mosh` script in `index.html`, `reviews/index.html`, `tools/index.html` and `tools/run.html`.
- Kept the original animated/interactive hero code intact and ensured the worklet is progressive (no-op if `CSS.paintWorklet` is not present) and that a CSS-only fallback is used in that case.

### Testing
- Started a local server with `python -m http.server 8000` and loaded `/reviews/` to validate the background script was referenced and the page rendered successfully.
- Ran a headless Playwright script to open `http://127.0.0.1:8000/reviews/`, waited for network idle, and captured a full-page screenshot which completed and produced an artifact (`artifacts/reviews-bg.png`).
- No unit tests exist for these static/front-end assets; the visual smoke-check above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614d73714483228f420c6ea8a0157e)