### PR TITLE
Add reviews index link and canonical metadata

### DIFF
--- a/reviews/gpac-bdu-2025.html
+++ b/reviews/gpac-bdu-2025.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>GPAC/MP4Box — уязвимости из БДУ ФСТЭК (2025)</title>
-  <meta name="description" content="Ранжирование и обзор уязвимостей GPAC/MP4Box по результатам выгрузки БДУ ФСТЭК (2025)." />
+  <title>Short-list по уязвимостям GPAC/MP4Box (2025)</title>
+  <meta name="description" content="Обзор уязвимостей GPAC/MP4Box по результатам выгрузки БДУ ФСТЭК на 2025 год" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://sigdevel.github.io/reviews/gpac-bdu-2025.html" />
   <style>

--- a/reviews/gpac-bdu-2025.html
+++ b/reviews/gpac-bdu-2025.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>GPAC/MP4Box — уязвимости из БДУ ФСТЭК (2025)</title>
   <meta name="description" content="Ранжирование и обзор уязвимостей GPAC/MP4Box по результатам выгрузки БДУ ФСТЭК (2025)." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://sigdevel.github.io/reviews/gpac-bdu-2025.html" />
   <style>
     :root {
       --bg: #0b0d10;

--- a/reviews/index.html
+++ b/reviews/index.html
@@ -43,6 +43,12 @@
                     </p>
                 </header>
             </section>
+            <section class="card">
+                <h2>Latest</h2>
+                <p>
+                    <a href="/reviews/gpac-bdu-2025.html">GPAC/MP4Box — уязвимости из БДУ ФСТЭК (2025)</a>
+                </p>
+            </section>
         </main>
     </div>
     <script src="/assets/engineering-bg.js" defer></script>

--- a/reviews/index.html
+++ b/reviews/index.html
@@ -33,6 +33,7 @@
                 <a href="/tools/">tools</a>
             </nav>
         </aside>
+
         <main class="content">
             <section class="card card--wide">
                 <header class="hero-header">
@@ -46,7 +47,7 @@
             <section class="card">
                 <h2>Latest</h2>
                 <p>
-                    <a href="/reviews/gpac-bdu-2025.html">GPAC/MP4Box — уязвимости из БДУ ФСТЭК (2025)</a>
+                    <a href="/reviews/gpac-bdu-2025.html">Обзор уязвимостей GPAC/MP4Box по результатам выгрузки БДУ ФСТЭК на 2025 год</a>
                 </p>
             </section>
         </main>


### PR DESCRIPTION
### Motivation
- Make the new GPAC/MP4Box review discoverable from the Reviews landing page.  
- Improve search engine indexing for the GPAC review page by providing canonical and robots metadata.  

### Description
- Added a `Latest` card to `reviews/index.html` that links to `/reviews/gpac-bdu-2025.html`.  
- Added `<meta name="robots" content="index, follow">` to `reviews/gpac-bdu-2025.html`.  
- Added a canonical link `<link rel="canonical" href="https://sigdevel.github.io/reviews/gpac-bdu-2025.html" />` to `reviews/gpac-bdu-2025.html`.  

### Testing
- Served the site locally with `python -m http.server 8000` and verified the updated `/reviews/` page renders.  
- Captured a full-page screenshot using Playwright to confirm the new link appears on the Reviews index.  
- Committed the changes and verified repository status with `git status` to ensure no unstaged files remained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fafe645c8322ba97b906b7aea2ab)