### PR TITLE
Run sitemap workflow on every push

### DIFF
--- a/.github/workflows/sitemap.yml
+++ b/.github/workflows/sitemap.yml
@@ -2,7 +2,6 @@ name: sitemap-gen
 
 on:
   push:
-    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+<loc>https://sigdevel.github.io/</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/google536380bffdc927b8.html</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/cv/</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/reviews/</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/reviews/gpac-bdu-2025.html</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/tools/</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+<url>
+<loc>https://sigdevel.github.io/tools/run.html</loc>
+<lastmod>2026-01-12T11:28:27+03:00</lastmod>
+</url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Ensure the sitemap is regenerated after every commit by triggering the `sitemap-gen` workflow on all `push` events.
- Previously the workflow only ran for pushes to the `main` branch, which could miss updates originating from other branches.

### Description
- Updated `.github/workflows/sitemap.yml` to remove the `branches: [ "main" ]` filter under the `on: push` trigger so the workflow runs on every push.
- No other job steps or logic were changed; the workflow still uses `cicirello/generate-sitemap@v1` and commits `sitemap.xml`.

### Testing
- No automated tests were run because this change only affects the workflow trigger and does not modify application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b01505d083229275898e94f3f5fe)